### PR TITLE
fix: Improved hanging wires rendering performance

### DIFF
--- a/src/SignalsMod.cs
+++ b/src/SignalsMod.cs
@@ -14,7 +14,7 @@ using Vintagestory.GameContent;
     "signals",
     Description = "Wires, triodes and more.",
     Website = "",
-    Version = "0.1.3",
+    Version = "0.2.7",
     Authors = new[] { "PFev" })]
 
 namespace signals.src

--- a/src/hangingwires/HangingWiresMod.cs
+++ b/src/hangingwires/HangingWiresMod.cs
@@ -74,6 +74,7 @@ namespace signals.src.hangingwires
             base.StartClientSide(api);
             capi = api;
             capi.Event.ChunkDirty += OnChunkDirty;
+            capi.Event.RegisterGameTickListener(OnClientTick, 16);
             api.Event.BlockTexturesLoaded += onLoaded;
             api.Event.LeaveWorld += () =>
             {
@@ -94,6 +95,11 @@ namespace signals.src.hangingwires
         {
             this.data = data;
             Renderer.dirty = true;
+        }
+
+        private void OnClientTick(float dt)
+        {
+            Renderer?.OnClientTick(dt);
         }
 
 

--- a/src/hangingwires/HangingWiresRenderer.cs
+++ b/src/hangingwires/HangingWiresRenderer.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System;
+using System.Diagnostics;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
@@ -23,6 +25,23 @@ namespace signals.src.hangingwires
         public Matrixf ModelMat = new Matrixf();
 
         Dictionary<Vec3i, MeshRef> MeshRefPerChunk;
+        Dictionary<Vec3i, MeshData> rebuildMeshPerChunk;
+        Dictionary<Vec3i, MeshRef> nextMeshRefPerChunk;
+        List<WireConnection> rebuildConnections;
+        int rebuildConnectionIndex;
+        List<KeyValuePair<Vec3i, MeshData>> uploadQueue;
+        int uploadIndex;
+
+        bool isRebuilding;
+        bool rebuildRequestedWhileRunning;
+
+        readonly AssetLocation wireTexName = new AssetLocation("signals:item/wire.png");
+        int wireTextureId = -1;
+
+        // Hard limits + time budget keep the per-tick cost bounded.
+        const int MaxConnectionsPerTick = 20;
+        const int MaxChunkUploadsPerTick = 1;
+        const double RebuildTimeBudgetMs = 2.0;
 
 
         public HangingWiresRenderer(ICoreClientAPI capi, HangingWiresMod mod)
@@ -40,10 +59,19 @@ namespace signals.src.hangingwires
         public void Dispose()
         {
             capi.Event.UnregisterRenderer(this, EnumRenderStage.Opaque);
-            if (MeshRefPerChunk == null) return;
-            foreach(MeshRef meshRef in MeshRefPerChunk.Values)
+            if (MeshRefPerChunk != null)
             {
-                meshRef?.Dispose();
+                foreach (MeshRef meshRef in MeshRefPerChunk.Values)
+                {
+                    meshRef?.Dispose();
+                }
+            }
+            if (nextMeshRefPerChunk != null)
+            {
+                foreach (MeshRef meshRef in nextMeshRefPerChunk.Values)
+                {
+                    meshRef?.Dispose();
+                }
             }
         }
 
@@ -57,14 +85,90 @@ namespace signals.src.hangingwires
             (255 << 24) | (255 << 16) | (0 << 8) | (255),
             (255 << 24) | (255 << 16) | (255 << 8) | (255)
         };
-        public void UpdateWiresMesh(HangingWiresData data)
+        void BeginMeshRebuild(HangingWiresData data)
         {
-
             IBlockAccessor accessor = capi?.World?.BlockAccessor;
-            IClientWorldAccessor world = capi?.World;
             if (data == null || accessor == null) return;
 
-            Dictionary<Vec3i, MeshData> MeshPerChunk = new Dictionary<Vec3i, MeshData>();
+            rebuildConnections = new List<WireConnection>(data.connections);
+            rebuildConnectionIndex = 0;
+            uploadQueue = null;
+            uploadIndex = 0;
+            rebuildMeshPerChunk = new Dictionary<Vec3i, MeshData>();
+            nextMeshRefPerChunk = new Dictionary<Vec3i, MeshRef>();
+            isRebuilding = true;
+        }
+
+        void ContinueMeshRebuild()
+        {
+            if (!isRebuilding) return;
+
+            Stopwatch sw = Stopwatch.StartNew();
+
+            IBlockAccessor accessor = capi?.World?.BlockAccessor;
+            if (accessor == null)
+            {
+                isRebuilding = false;
+                return;
+            }
+
+            if (uploadQueue == null)
+            {
+                int processedConnections = 0;
+                for (; rebuildConnectionIndex < rebuildConnections.Count; rebuildConnectionIndex++)
+                {
+                    if (processedConnections >= MaxConnectionsPerTick) break;
+                    if (sw.Elapsed.TotalMilliseconds >= RebuildTimeBudgetMs) break;
+
+                    WireConnection con = rebuildConnections[rebuildConnectionIndex];
+                    processedConnections++;
+
+                    IHangingWireAnchor block1 = accessor.GetBlock(con.pos1.blockPos) as IHangingWireAnchor;
+                    IHangingWireAnchor block2 = accessor.GetBlock(con.pos2.blockPos) as IHangingWireAnchor;
+                    if (block1 == null || block2 == null) continue;
+
+                    BlockPos blockPos1 = con.pos1.blockPos;
+                    Vec3i chunkpos = new Vec3i(blockPos1.X / chunksize, blockPos1.Y / chunksize, blockPos1.Z / chunksize);
+
+                    Vec3f pos1 = con.pos1.blockPos.ToVec3f().AddCopy(-chunkpos.X * chunksize, -chunkpos.Y * chunksize, -chunkpos.Z * chunksize) + block1.GetAnchorPosInBlock(con.pos1);
+                    Vec3f pos2 = con.pos2.blockPos.ToVec3f().AddCopy(-chunkpos.X * chunksize, -chunkpos.Y * chunksize, -chunkpos.Z * chunksize) + block2.GetAnchorPosInBlock(con.pos2);
+
+                    if (rebuildMeshPerChunk.TryGetValue(chunkpos, out MeshData mesh))
+                    {
+                        mesh.AddMeshData(WireMesh.MakeWireMesh(pos1, pos2));
+                    }
+                    else
+                    {
+                        rebuildMeshPerChunk[chunkpos] = WireMesh.MakeWireMesh(pos1, pos2);
+                    }
+                }
+
+                if (rebuildConnectionIndex < rebuildConnections.Count)
+                {
+                    return;
+                }
+
+                uploadQueue = new List<KeyValuePair<Vec3i, MeshData>>(rebuildMeshPerChunk);
+                rebuildConnections = null;
+                rebuildMeshPerChunk = null;
+            }
+
+            int uploadedChunks = 0;
+            for (; uploadIndex < uploadQueue.Count; uploadIndex++)
+            {
+                if (uploadedChunks >= MaxChunkUploadsPerTick) break;
+                if (sw.Elapsed.TotalMilliseconds >= RebuildTimeBudgetMs) break;
+
+                KeyValuePair<Vec3i, MeshData> mesh = uploadQueue[uploadIndex];
+                mesh.Value.SetMode(EnumDrawMode.Triangles);
+                nextMeshRefPerChunk[mesh.Key] = capi.Render.UploadMesh(mesh.Value);
+                uploadedChunks++;
+            }
+
+            if (uploadIndex < uploadQueue.Count)
+            {
+                return;
+            }
 
             if (MeshRefPerChunk != null)
             {
@@ -73,54 +177,43 @@ namespace signals.src.hangingwires
                     meshRef?.Dispose();
                 }
             }
-            MeshRefPerChunk = new Dictionary<Vec3i, MeshRef>();
 
-
-            foreach (WireConnection con in data.connections)
-            {
-
-                    IHangingWireAnchor block1 = accessor.GetBlock(con.pos1.blockPos) as IHangingWireAnchor;
-                    IHangingWireAnchor block2 = accessor.GetBlock(con.pos2.blockPos) as IHangingWireAnchor;
-                    if (block1 == null || block2 == null) continue;
-
-
-                    BlockPos blockPos1 = con.pos1.blockPos;
-                    Vec3i chunkpos = new Vec3i(blockPos1.X / chunksize, blockPos1.Y / chunksize, blockPos1.Z / chunksize);
-
-                    Vec3f pos1 = con.pos1.blockPos.ToVec3f().AddCopy(-chunkpos.X*chunksize,-chunkpos.Y*chunksize,-chunkpos.Z*chunksize) + block1.GetAnchorPosInBlock(con.pos1);
-                    Vec3f pos2 = con.pos2.blockPos.ToVec3f().AddCopy(-chunkpos.X * chunksize, -chunkpos.Y * chunksize, -chunkpos.Z * chunksize) + block2.GetAnchorPosInBlock(con.pos2);
-
-                    if (MeshPerChunk.ContainsKey(chunkpos))
-                    {
-                        MeshData newMesh = WireMesh.MakeWireMesh(pos1, pos2);
-                        MeshPerChunk[chunkpos].AddMeshData(newMesh);
-
-                    }
-                    else
-                    {
-                        MeshPerChunk[chunkpos] = WireMesh.MakeWireMesh(pos1, pos2);
-                    }
-
-            }
-
-            foreach(KeyValuePair<Vec3i, MeshData> mesh in MeshPerChunk)
-            {
-                mesh.Value.SetMode(EnumDrawMode.Triangles);
-                MeshRefPerChunk[mesh.Key] = capi.Render.UploadMesh(mesh.Value);
-            }
-            MeshPerChunk.Clear();
+            MeshRefPerChunk = nextMeshRefPerChunk;
+            nextMeshRefPerChunk = null;
+            uploadQueue = null;
+            isRebuilding = false;
 
         }
 
-        public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
+        public void OnClientTick(float dt)
         {
             if (dirty)
             {
-                // TODO: fix this, it is ugly
-                HangingWiresData data = capi.ModLoader.GetModSystem<HangingWiresMod>()?.data;
-                UpdateWiresMesh(data);
+                if (isRebuilding)
+                {
+                    rebuildRequestedWhileRunning = true;
+                }
+                else
+                {
+                    HangingWiresData data = capi.ModLoader.GetModSystem<HangingWiresMod>()?.data;
+                    BeginMeshRebuild(data);
+                }
                 dirty = false;
             }
+
+            ContinueMeshRebuild();
+
+            if (!isRebuilding && rebuildRequestedWhileRunning)
+            {
+                HangingWiresData data = capi.ModLoader.GetModSystem<HangingWiresMod>()?.data;
+                BeginMeshRebuild(data);
+                rebuildRequestedWhileRunning = false;
+                ContinueMeshRebuild();
+            }
+            }
+
+            public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
+            {
             if (MeshRefPerChunk == null) return;
             if (stage != EnumRenderStage.Opaque) return;
 
@@ -135,20 +228,28 @@ namespace signals.src.hangingwires
             IStandardShaderProgram prog = rpi.PreparedStandardShader(0, 0, 0);
             prog.Use();
 
-            AssetLocation wireTexName = new AssetLocation("signals:item/wire.png");
-
-            int texid = capi.Render.GetOrLoadTexture(wireTexName);
-            rpi.BindTexture2d(texid);
+            if (wireTextureId < 0)
+            {
+                wireTextureId = capi.Render.GetOrLoadTexture(wireTexName);
+            }
+            rpi.BindTexture2d(wireTextureId);
 
             prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
             prog.ViewMatrix = rpi.CameraMatrixOriginf;
 
             prog.ModelMatrix = ModelMat.Values;
 
+            float maxRenderDistance = RenderRange + chunksize;
+            float maxRenderDistanceSq = maxRenderDistance * maxRenderDistance;
+
             foreach(KeyValuePair<Vec3i,MeshRef> mesh in MeshRefPerChunk)
             {
-                //worldAccess.BlockAccessor.GetLightRGBs()
-                Vec3d offset = new Vec3d(mesh.Key.X*chunksize, mesh.Key.Y * chunksize, mesh.Key.Z * chunksize);
+                Vec3d offset = new Vec3d(mesh.Key.X * chunksize, mesh.Key.Y * chunksize, mesh.Key.Z * chunksize);
+                double cx = offset.X + chunksize * 0.5 - camPos.X;
+                double cy = offset.Y + chunksize * 0.5 - camPos.Y;
+                double cz = offset.Z + chunksize * 0.5 - camPos.Z;
+                if (cx * cx + cy * cy + cz * cz > maxRenderDistanceSq) continue;
+
                 prog.ModelMatrix = ModelMat.Identity().Translate(offset.X - camPos.X, offset.Y - camPos.Y, offset.Z - camPos.Z).Values;
                 rpi.RenderMesh(mesh.Value);
             }

--- a/src/hangingwires/WireMesh.cs
+++ b/src/hangingwires/WireMesh.cs
@@ -64,7 +64,7 @@ namespace signals.src.hangingwires
             mesh_side.Flags.Fill(0);
             mesh_side2.Flags.Fill(0);
 
-            Vec3f[] positions = [];
+            Vec3f[] positions = new Vec3f[nSec + 1];
             for (int j = 0; j <= nSec; j++)
             {
                 float x = dPos.X / nSec * j;
@@ -72,7 +72,7 @@ namespace signals.src.hangingwires
                 float z = dPos.Z / nSec * j;
                 float l = (float)Math.Sqrt(x * x + y * y + z * z);
                 float dy = Catenary(l / dist, 1, 2f);
-                positions = positions.Append(new Vec3f(x, y + dy, z));
+                positions[j] = new Vec3f(x, y + dy, z);
             }
 
             Vec3f pos;


### PR DESCRIPTION
Hi VonZeeple!
I made some hanging wires optimization. It should help to solve problem with lags. As we're using Signals more and more, we've a lot of wires and we started experiencing lags every time when we entered to chunks with those wires.
So I made a fork of Signals and optimized it a little bit. I refactored hanging wire mesh generation to run incrementally on client ticks instead of inside the Opaque render callback, so heavy rebuild/upload work no longer blocks rendering in large chunk-load bursts. The rebuild pipeline now processes bounded batches with a strict time budget, debounces repeated dirty events while a rebuild is already running, and swaps old/new mesh sets only after the new set is fully ready. I also reduced per-frame rendering overhead by caching the wire texture, adding distance-based chunk culling, and removing avoidable allocations in WireMesh (replacing per-iteration array appends with fixed-size indexing).

Please look at it. I hope thjat you'll approve this optimization.