### PR TITLE
fix: missing cleanup on network device unloading

### DIFF
--- a/src/signalNetwork/SignalNetworkMod.cs
+++ b/src/signalNetwork/SignalNetworkMod.cs
@@ -203,7 +203,11 @@ namespace signals.src
 
         internal void OnDeviceUnloaded(ISignalNodeProvider device)
         {
-            
+            if(this.Api.Side == EnumAppSide.Client) return;
+            Dictionary<NodePos,ISignalNode> nodes = device.GetNodes();
+            netManager.RemoveNodes(nodes.Values.ToArray());
+            devicesToLoad.Remove(device);
+            needRenderUpdate = true;
         }
 
         internal void OnDeviceInitialized(ISignalNodeProvider device)


### PR DESCRIPTION
When one chunk of a network was unloaded and another chunks with devices from the same network remained loaded, it started writting errors "Network XY already contains a node at pos Z" to the server log after loading the previously unloaded chunk. 
This situation could later causing more errors and client disconnecting, when player uses a devices from the network.
Thre was missing cleanup of the unloaded nodes.