### PR TITLE
fix: preventing self-loop wiring to same anchor, preventing duplicate connections

### DIFF
--- a/src/hangingwires/HangingWiresMod.cs
+++ b/src/hangingwires/HangingWiresMod.cs
@@ -181,6 +181,7 @@ namespace signals.src.hangingwires
         }
 
         public bool TryToAddConnection(WireConnection connection){
+            if (connection.pos1 == connection.pos2) return false;
             bool added = data.connections.Add(connection);
             if (added)
             {

--- a/src/signalNetwork/NetworkManager.cs
+++ b/src/signalNetwork/NetworkManager.cs
@@ -114,6 +114,11 @@ namespace signals.src.signalNetwork
         /// </summary>
         public void AddConnection(Connection con)
         {
+            foreach (Connection existing in con.node1.Connections)
+            {
+                if (existing.GetOther(con.node1) == con.node2) return;
+            }
+
             con.node1.Connections.Add(con);
             con.node2.Connections.Add(con);
 
@@ -207,7 +212,7 @@ namespace signals.src.signalNetwork
             HashSet<long> netToRebuild = new HashSet<long>();
             foreach (ISignalNode node in nodes)
             {
-                foreach (Connection con in node.Connections)
+                foreach (Connection con in node.Connections.ToList())
                 {
                     ISignalNode otherNode = con.GetOther(node);
                     otherNode.Connections.Remove(con);


### PR DESCRIPTION
Fixed a "Collection was modified during enumeration" crash in RemoveNodes that occurred when breaking blocks with self-loop wire connections, by iterating over a copy of the connections list. Added a guard in TryToAddConnection to reject self-loop wires where both ends point to the same node. Prevented duplicate runtime Connection objects from being created during chunk loading by checking for existing connections in AddConnection before adding new ones.